### PR TITLE
Fix the wrong counting method

### DIFF
--- a/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
+++ b/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
@@ -12,7 +12,7 @@
     },
     {
       "item": "minecraft:sand",
-    }，
+    },
     {
       "type": "fluid_tag",
       "fluid_tag": "c:crude_oil",

--- a/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
+++ b/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
@@ -2,13 +2,17 @@
   "type": "create:mixing",
   "ingredients": [
     {
-      "item": "minecraft:gravel",
-      "count": 2
+      "item": "minecraft:gravel"
+    },
+    {
+      "item": "minecraft:gravel"
     },
     {
       "item": "minecraft:sand",
-      "count": 2
     },
+    {
+      "item": "minecraft:sand",
+    }，
     {
       "type": "fluid_tag",
       "fluid_tag": "c:crude_oil",

--- a/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
+++ b/src/main/resources/data/createdieselgenerators/recipe/mixing/asphalt_block.json
@@ -8,10 +8,10 @@
       "item": "minecraft:gravel"
     },
     {
-      "item": "minecraft:sand",
+      "item": "minecraft:sand"
     },
     {
-      "item": "minecraft:sand",
+      "item": "minecraft:sand"
     },
     {
       "type": "fluid_tag",


### PR DESCRIPTION
Create's Mixing recipe don't accept "count", you should repeatedly enter the ingredient you want to multiply instead.

<img width="750" height="467" alt="image" src="https://github.com/user-attachments/assets/5e575e21-8e27-4a4d-a1df-eb793dc53ed0" />

You can see that the in-game recipe only cosume **1 gravel and 1 sand**, not 2 as expect.