### PR TITLE
Fix the the wrong tag in recipe, and the crash when storing tracks with components in Track Layers Bag

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/track_layers_bag/TrackLayersBagItem.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/track_layers_bag/TrackLayersBagItem.java
@@ -12,6 +12,7 @@ import com.tterrag.registrate.providers.RegistrateItemModelProvider;
 import net.createmod.catnip.platform.CatnipServices;
 import net.minecraft.client.renderer.item.ItemProperties;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionResult;
@@ -50,7 +51,7 @@ public class TrackLayersBagItem extends Item {
     int add(ItemStack bag, ItemStack stack) {
         if (!stack.isEmpty() && stack.getItem() instanceof TrackBlockItem) {
             ItemStack stackInBag = getTracks(bag);
-            if(!ItemStack.isSameItemSameComponents(stack, stackInBag) && !stackInBag.isEmpty())
+            if(stack.getItem() != stackInBag.getItem() && !stackInBag.isEmpty())
                 return 0;
 
             int oldCount = stackInBag.getCount();
@@ -139,12 +140,9 @@ public class TrackLayersBagItem extends Item {
 
     public static ItemStack getTracks(ItemStack stack) {
         TrackLayersBagItemDataComponent component = stack.get(CDGDataComponents.TRACKS);
-        ItemStack trackStack;
         if (component == null)
-            trackStack = ItemStack.EMPTY;
-        else
-            trackStack = component.stack().copyWithCount(component.count());
-        return trackStack;
+            return ItemStack.EMPTY;
+        return component.toStack();
     }
 
     @Override

--- a/src/main/java/com/jesz/createdieselgenerators/content/track_layers_bag/TrackLayersBagItemDataComponent.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/track_layers_bag/TrackLayersBagItemDataComponent.java
@@ -2,41 +2,51 @@ package com.jesz.createdieselgenerators.content.track_layers_bag;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.ExtraCodecs;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 import java.util.Objects;
 
-public record TrackLayersBagItemDataComponent(ItemStack stack, int count) {
+public record TrackLayersBagItemDataComponent(ResourceLocation itemId, int count) {
+
     public static final Codec<TrackLayersBagItemDataComponent> CODEC = RecordCodecBuilder.create(instance -> instance
             .group(
-                    ItemStack.OPTIONAL_CODEC.fieldOf("item").forGetter(TrackLayersBagItemDataComponent::stack),
+                    ResourceLocation.CODEC.fieldOf("item").forGetter(TrackLayersBagItemDataComponent::itemId),
                     ExtraCodecs.NON_NEGATIVE_INT.fieldOf("count").forGetter(TrackLayersBagItemDataComponent::count)
             )
             .apply(instance, TrackLayersBagItemDataComponent::new));
 
     public static final StreamCodec<RegistryFriendlyByteBuf, TrackLayersBagItemDataComponent> STREAM_CODEC =
             StreamCodec.composite(
-                    ItemStack.STREAM_CODEC, TrackLayersBagItemDataComponent::stack,
+                    ResourceLocation.STREAM_CODEC, TrackLayersBagItemDataComponent::itemId,
                     ByteBufCodecs.VAR_INT, TrackLayersBagItemDataComponent::count,
                     TrackLayersBagItemDataComponent::new);
 
     public TrackLayersBagItemDataComponent(ItemStack stack) {
-        this(stack.copyWithCount(1), stack.getCount());
+        this(BuiltInRegistries.ITEM.getKey(stack.getItem()), stack.getCount());
+    }
+
+    public ItemStack toStack() {
+        Item item = BuiltInRegistries.ITEM.get(itemId);
+        if (item == null) return ItemStack.EMPTY;
+        return new ItemStack(item, count);
     }
 
     @Override
     public boolean equals(Object obj) {
         if (!(obj instanceof TrackLayersBagItemDataComponent t))
             return false;
-        return t.count() == count() && ItemStack.isSameItemSameComponents(stack, t.stack);
+        return t.count() == count() && t.itemId().equals(itemId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(count(), stack().getComponents(), stack().getItem());
+        return Objects.hash(itemId(), count());
     }
 }

--- a/src/main/resources/data/createdieselgenerators/recipe/crushing/wood_chip_chests.json
+++ b/src/main/resources/data/createdieselgenerators/recipe/crushing/wood_chip_chests.json
@@ -2,7 +2,7 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "tag": "forge:chests/wooden"
+      "tag": "c:chests/wooden"
     }
   ],
   "results": [


### PR DESCRIPTION
## The crash when storing tracks with components in Track Layers Bag #274 

**Problem**  
The previous implementation stored a full `ItemStack` inside the `DataComponent` and used `ItemStack.STREAM_CODEC` for synchronization.
However, in some cases, `ItemStacks` cannot be properly serialized over the network, which may cause a crash.:
`Failed to encode packet 'clientbound/minecraft:container_set_slot'`

**Solution**
Reworked TrackLayersBagItemDataComponent to store only:
- ResourceLocation itemId
- int count

Reconstructed ItemStack on demand instead of storing full stack data.
Removed reliance on ItemStack.STREAM_CODEC for unsafe data.

## The the wrong tag in recipe #272 

Corrected the wrong tag `forge:chests/wooden` to `c:chests/wooden`