### PR TITLE
fix NullPointerException on loadLootTable

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/events/GameEvents.java
+++ b/src/main/java/com/jesz/createdieselgenerators/events/GameEvents.java
@@ -73,6 +73,7 @@ public class GameEvents {
     public static void loadLootTable(LootTableLoadEvent event){
         LootTable table = event.getTable();
         ResourceLocation tableId = table.getLootTableId();
+        if (tableId == null) return;
         if (!tableId.getPath().startsWith("entities/"))
                 return;
 


### PR DESCRIPTION
EMI Loot sometimes calls `loadLootTable` with an empty `tableId`, which would cause an error. This fixes that.