### PR TITLE
feat: Engines, analog control and stalling

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/CDGConfig.java
+++ b/src/main/java/com/jesz/createdieselgenerators/CDGConfig.java
@@ -46,6 +46,7 @@ public class CDGConfig {
     public static final ModConfigSpec.ConfigValue<Boolean> HUGE_ENGINES;
     public static final ModConfigSpec.ConfigValue<Boolean> ENGINES_FILLED_WITH_ITEMS;
     public static final ModConfigSpec.ConfigValue<Boolean> ENGINES_DISABLED_WITH_REDSTONE;
+    public static final ModConfigSpec.ConfigValue<Boolean> ANALOG_SPEED_CONTROL;
 
     static {
 
@@ -79,6 +80,9 @@ public class CDGConfig {
                     .define("Engines filled with a bucket", false);
             ENGINES_DISABLED_WITH_REDSTONE = SERVER_BUILDER.comment("Whenever Diesel Engines can be disabled with redstone")
                     .define("Engines disabled with redstone", true);
+
+            ANALOG_SPEED_CONTROL = SERVER_BUILDER.comment("If Diesel Engines can be controlled with a analog lever.")
+                    .define("Engines controlled by analog lever", true);
 
         SERVER_BUILDER.pop();
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
@@ -4,6 +4,7 @@ import com.jesz.createdieselgenerators.CDGConfig;
 import com.jesz.createdieselgenerators.CDGRegistries;
 import com.jesz.createdieselgenerators.content.diesel_engine.normal.DieselEngineBlock;
 import com.jesz.createdieselgenerators.fuel_type.FuelType;
+import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
@@ -11,9 +12,14 @@ import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 public interface IEngine {
 
     default boolean enabled() {
-        if (validFS())
-            return !(CDGConfig.ENGINES_DISABLED_WITH_REDSTONE.get() && self().getBlockState().getValue(DieselEngineBlock.POWERED));
-        return false;
+        if (!validFS())
+            return false;
+        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
+            return false;
+        if (CDGConfig.ANALOG_SPEED_CONTROL.get())
+            return true;
+        return !(CDGConfig.ENGINES_DISABLED_WITH_REDSTONE.get()
+                && self().getBlockState().getValue(DieselEngineBlock.POWERED));
     }
 
     default boolean validFS() {
@@ -45,7 +51,17 @@ public interface IEngine {
         return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()).soundPitch();
     }
 
-    float getRemainingTicks();
+    int getAnalogSignal();
+
+    default float getThrottle() {
+        return CDGConfig.ANALOG_SPEED_CONTROL.get() ? (15 - getAnalogSignal()) / 15f : 1f;
+    }
+
+    default float getFuelThrottle() {
+        float throttle = getThrottle();
+        if (throttle == 0f) return 0f;
+        return 0.25f + (throttle * 0.75f);
+    }
 
     SmartBlockEntity self();
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
@@ -14,8 +14,6 @@ public interface IEngine {
     default boolean enabled() {
         if (!validFS())
             return false;
-        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
-            return false;
         if (CDGConfig.ANALOG_SPEED_CONTROL.get())
             return true;
         return !(CDGConfig.ENGINES_DISABLED_WITH_REDSTONE.get()

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/IEngine.java
@@ -20,34 +20,51 @@ public interface IEngine {
                 && self().getBlockState().getValue(DieselEngineBlock.POWERED));
     }
 
+    FuelType getCachedFuelType();
+    void setCachedFuelType(FuelType type);
+    FluidStack getLastCachedFluid();
+    void setLastCachedFluid(FluidStack fluid);
+    float getCachedFuelSpeed();
+    void setCachedFuelSpeed(float speed);
+    float getCachedFuelCapacity();
+    void setCachedFuelCapacity(float capacity);
+    float getCachedBurnRate();
+    void setCachedBurnRate(float rate);
+
+    default void invalidateFuelCache() {
+        setLastCachedFluid(FluidStack.EMPTY);
+    }
+
+    default FuelType getFuelType() {
+        FluidStack current = getTank().getFluid();
+        if (!FluidStack.isSameFluid(current, getLastCachedFluid())) {
+            setLastCachedFluid(current.copy());
+            FuelType type = FuelType.getTypeFor(
+                    self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE),
+                    current.getFluid());
+            setCachedFuelType(type);
+            float speed = type.getGenerated(self()).speed();
+            setCachedFuelSpeed(speed);
+            setCachedFuelCapacity(speed == 0 ? 0 :
+                    type.getGenerated(self()).strength() / speed);
+            setCachedBurnRate(type.getGenerated(self()).burn());
+        }
+        return getCachedFuelType();
+    }
+
     default boolean validFS() {
-        if (fs().isEmpty())
-            return false;
-        return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()) != FuelType.EMPTY;
+        if (fs().isEmpty()) return false;
+        return getFuelType() != FuelType.EMPTY;
     }
 
     default FluidStack fs() {
         return getTank().getFluid();
     }
 
-    default float getFuelSpeed() {
-        return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()).getGenerated(self()).speed();
-    }
-
-    default float getFuelCapacity() {
-        float speed = getFuelSpeed();
-        if (speed == 0)
-            return speed;
-        return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()).getGenerated(self()).strength() / speed;
-    }
-
-    default float getFuelBurnRate() {
-        return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()).getGenerated(self()).burn();
-    }
-
-    default float getFuelSoundPitch() {
-        return FuelType.getTypeFor(self().getLevel().registryAccess().lookupOrThrow(CDGRegistries.FUEL_TYPE), fs().getFluid()).soundPitch();
-    }
+    default float getFuelSpeed() { getFuelType(); return getCachedFuelSpeed(); }
+    default float getFuelCapacity() { getFuelType(); return getCachedFuelCapacity(); }
+    default float getFuelBurnRate() { getFuelType(); return getCachedBurnRate(); }
+    default float getFuelSoundPitch() { return getFuelType().soundPitch(); }
 
     int getAnalogSignal();
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlock.java
@@ -30,6 +30,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
@@ -143,6 +144,18 @@ public class HugeDieselEngineBlock extends Block implements IBE<HugeDieselEngine
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos otherPos, boolean moving) {
         level.setBlockAndUpdate(pos, state.setValue(POWERED, level.hasNeighborSignal(pos)));
+
+        if (CDGConfig.ANALOG_SPEED_CONTROL.get()) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof HugeDieselEngineBlockEntity engine) {
+                int newSignal = level.getBestNeighborSignal(pos);
+                if (newSignal != engine.analogSignal) {
+                    engine.setAnalogSignal(newSignal);
+                    engine.setSignalChanged(true);
+                }
+            }
+        }
+
         super.neighborChanged(state, level, pos, block, otherPos, moving);
     }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
@@ -67,7 +67,6 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
 
     public HugeDieselEngineBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
-        setLazyTickRate(10);
     }
 
     @Override
@@ -95,35 +94,22 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     }
 
     @Override
-    public void lazyTick() {
-        super.lazyTick();
+    public void tick() {
+        super.tick();
+
         PoweredEngineShaftBlockEntity shaft = getShaft();
         boolean wasOverStressed = overStressed;
         overStressed = shaft != null && shaft.isOverStressed();
-
         if (wasOverStressed && !overStressed)
             signalChanged = true;
 
         if (!overStressed && enabled() && getThrottle() > 0 && needsShaftRegistration)
             signalChanged = true;
 
-        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
-        int power = level.getBestNeighborSignal(getBlockPos());
-        if (power != analogSignal) {
-            analogSignal = power;
-            signalChanged = true;
-        }
-    }
-
-    @Override
-    public void tick() {
-        super.tick();
-
         if (signalChanged) {
             signalChanged = false;
             setChanged();
             sendData();
-            PoweredEngineShaftBlockEntity shaft = getShaft();
             if (shaft != null && enabled() && getThrottle() > 0) {
                 float throttle = getThrottle();
                 shaft.update(worldPosition,
@@ -140,7 +126,6 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         if (overStressed)
             return;
 
-        PoweredEngineShaftBlockEntity shaft = getShaft();
         if (shaft == null)
             return;
 
@@ -328,4 +313,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     @Override public void setCachedFuelCapacity(float c) { cachedFuelCapacity = c; }
     @Override public float getCachedBurnRate() { return cachedBurnRate; }
     @Override public void setCachedBurnRate(float r) { cachedBurnRate = r; }
+
+    public void setAnalogSignal(int newSignal) { analogSignal = newSignal; }
+    public void setSignalChanged(boolean newSignal) { signalChanged = newSignal; }
 }

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
@@ -15,9 +15,11 @@ import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
 import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.fluid.SmartFluidTankBehaviour;
 import com.simibubi.create.foundation.blockEntity.behaviour.scrollValue.ScrollOptionBehaviour;
+import com.simibubi.create.foundation.item.TooltipHelper;
 import com.simibubi.create.foundation.utility.CreateLang;
 import net.createmod.catnip.data.Couple;
 import net.createmod.catnip.data.Pair;
+import net.createmod.catnip.lang.FontHelper;
 import net.createmod.catnip.platform.CatnipServices;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.Minecraft;
@@ -45,6 +47,7 @@ import java.lang.ref.WeakReference;
 import java.util.List;
 
 import static com.jesz.createdieselgenerators.content.diesel_engine.huge.HugeDieselEngineBlock.FACING;
+import static net.minecraft.ChatFormatting.GOLD;
 
 public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHaveGoggleInformation, IEngine {
     ScrollOptionBehaviour<WindmillBearingBlockEntity.RotationDirection> movementDirection;
@@ -231,32 +234,37 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
 
     @Override
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
-        if (!IRotate.StressImpact.isEnabled() || !enabled())
-            return false;
-        PoweredEngineShaftBlockEntity shaft = getShaft();
-        if(shaft == null)
-            return false;
-        float stressBase = upgrade.getCapacity(getFuelCapacity(), this) *
-                upgrade.getSpeed(getFuelSpeed(), this) * getThrottle();
+        if (overStressed) {
+            CreateLang.translate("gui.stressometer.overstressed")
+                    .style(GOLD)
+                    .forGoggles(tooltip);
+            Component hint = CreateLang.translateDirect("gui.contraptions.network_overstressed");
+            List<Component> cutString = TooltipHelper.cutTextComponent(hint, FontHelper.Palette.GRAY_AND_WHITE);
+            for (Component component : cutString)
+                CreateLang.builder().add(component.copy()).forGoggles(tooltip);
+            return containedFluidTooltip(tooltip, isPlayerSneaking, tank.getCapability());
+        }
 
-        if (Mth.equal(stressBase, 0))
-            return false;
+        if (IRotate.StressImpact.isEnabled() && enabled() && getThrottle() > 0) {
+            PoweredEngineShaftBlockEntity shaft = getShaft();
+            if (shaft != null) {
+                float stressBase = upgrade.getCapacity(getFuelCapacity(), this) *
+                        upgrade.getSpeed(getFuelSpeed(), this) * getThrottle();
+                if (!Mth.equal(stressBase, 0)) {
+                    CreateLang.translate("gui.goggles.generator_stats").forGoggles(tooltip);
+                    CreateLang.translate("tooltip.capacityProvided")
+                            .style(ChatFormatting.GRAY).forGoggles(tooltip);
+                    CreateLang.number(Math.abs(stressBase))
+                            .translate("generic.unit.stress")
+                            .style(ChatFormatting.AQUA)
+                            .space()
+                            .add(CreateLang.translate("gui.goggles.at_current_speed")
+                                    .style(ChatFormatting.DARK_GRAY))
+                            .forGoggles(tooltip, 1);
+                }
+            }
+        }
 
-        CreateLang.translate("gui.goggles.generator_stats")
-                .forGoggles(tooltip);
-        CreateLang.translate("tooltip.capacityProvided")
-                .style(ChatFormatting.GRAY)
-                .forGoggles(tooltip);
-
-        float stressTotal = Math.abs(stressBase);
-
-        CreateLang.number(stressTotal)
-                .translate("generic.unit.stress")
-                .style(ChatFormatting.AQUA)
-                .space()
-                .add(CreateLang.translate("gui.goggles.at_current_speed")
-                        .style(ChatFormatting.DARK_GRAY))
-                .forGoggles(tooltip, 1);
         return containedFluidTooltip(tooltip, isPlayerSneaking, tank.getCapability());
     }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
@@ -2,6 +2,7 @@ package com.jesz.createdieselgenerators.content.diesel_engine.huge;
 
 import com.jesz.createdieselgenerators.CDGBlockEntityTypes;
 import com.jesz.createdieselgenerators.CDGBlocks;
+import com.jesz.createdieselgenerators.CDGConfig;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineSoundInstance;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineUpgrades;
 import com.jesz.createdieselgenerators.content.diesel_engine.IEngine;
@@ -45,29 +46,34 @@ import static com.jesz.createdieselgenerators.content.diesel_engine.huge.HugeDie
 
 public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHaveGoggleInformation, IEngine {
     ScrollOptionBehaviour<WindmillBearingBlockEntity.RotationDirection> movementDirection;
-    float remainingTicks = 0;
     EngineUpgrades upgrade = EngineUpgrades.EMPTY;
     SmartFluidTankBehaviour tank;
     WeakReference<PoweredEngineShaftBlockEntity> target = new WeakReference<>(null);
+    public int analogSignal = 0;
+    private boolean signalChanged = false;
+    private float fuelDebt = 0f;
+    boolean overStressed = false;
 
     public HugeDieselEngineBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
-
+        setLazyTickRate(10);
     }
 
     @Override
     protected void write(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.write(tag, registries, clientPacket);
-        tag.putFloat("RemainingTicks", remainingTicks);
         tag.putString("Upgrade", upgrade.getId().toString());
+        tag.putInt("AnalogSignal", analogSignal);
+        tag.putFloat("fuelDebt", fuelDebt);
 
     }
 
     @Override
     protected void read(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(tag, registries, clientPacket);
-        remainingTicks = tag.getFloat("RemainingTicks");
         upgrade = EngineUpgrades.get(ResourceLocation.parse(tag.getString("Upgrade")));
+        analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 0;
+        fuelDebt = tag.contains("fuelDebt") ? tag.getFloat("fuelDebt") : 0f;
     }
 
     @Override
@@ -76,28 +82,56 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     }
 
     @Override
+    public void lazyTick() {
+        super.lazyTick();
+        PoweredEngineShaftBlockEntity shaft = getShaft();
+        overStressed = shaft != null && shaft.isOverStressed();
+
+        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
+        int power = level.getBestNeighborSignal(getBlockPos());
+        if (power != analogSignal) {
+            analogSignal = power;
+            signalChanged = true;
+        }
+    }
+
+    @Override
     public void tick() {
         super.tick();
+
+        if (signalChanged) {
+            signalChanged = false;
+            sendData();
+        }
+
+        if (overStressed) {
+            PoweredEngineShaftBlockEntity shaft = getShaft();
+            if (shaft != null)
+                shaft.removeGenerator(worldPosition);
+            return;
+        }
+
         PoweredEngineShaftBlockEntity shaft = getShaft();
         if (shaft == null)
             return;
 
-        if (enabled()) {
-            if (remainingTicks < 2) {
-                remainingTicks += 1 / getFuelBurnRate();
-                tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
-            }
-
-            if (remainingTicks >= 0)
-                remainingTicks--;
-
+        if (enabled() && getThrottle() > 0) {
             if (shaft.movementDirection != 0 && shaft.movementDirection != (movementDirection.get() == WindmillBearingBlockEntity.RotationDirection.CLOCKWISE ? 1 : -1)) {
                 shaft.removeGenerator(worldPosition);
                 onDirectionChanged(movementDirection.getValue());
                 return;
             }
 
-            shaft.update(worldPosition, movementDirection.getValue() == 0 ? 1 : -1, upgrade.getCapacity(getFuelCapacity(), this), upgrade.getSpeed(getFuelSpeed(), this));
+            float throttle = getThrottle();
+            float speed = upgrade.getSpeed(getFuelSpeed(), this) * throttle;
+            float capacity = upgrade.getCapacity(getFuelCapacity(), this);
+            shaft.update(worldPosition, movementDirection.getValue() == 0 ? 1 : -1, capacity, speed);
+
+            fuelDebt += getFuelBurnRate() * getFuelThrottle();
+            while (fuelDebt >= 1f) {
+                tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
+                fuelDebt -= 1f;
+            }
 
             if (level.isClientSide)
                 CatnipServices.PLATFORM.executeOnClientOnly(() -> this::tickClient);
@@ -117,8 +151,8 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
                         .play(soundInstance = upgrade.createSoundInstance(this, Vec3.atCenterOf(getBlockPos())));
             } else if (soundInstance.active()) {
                 soundInstance.keepAlive();
-                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch() / 2);
-                soundInstance.setVolume(upgrade.getVolume(this));
+                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch() / 2 * getThrottle());
+                soundInstance.setVolume(upgrade.getVolume(this)* getThrottle());
             }
         } else {
             if (soundInstance != null) {
@@ -135,7 +169,6 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
             if (shaft != null)
                 target = new WeakReference<>(null);
             BlockEntity anyShaftAt = level.getBlockEntity(worldPosition.relative(getBlockState().getValue(FACING), 2));
-            BlockState sState = level.getBlockState(worldPosition.relative(getBlockState().getValue(FACING), 2));
             if (anyShaftAt instanceof PoweredEngineShaftBlockEntity ps)
                 target = new WeakReference<>(shaft = ps);
         }
@@ -179,7 +212,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         if(shaft == null)
             return false;
         float stressBase = upgrade.getCapacity(getFuelCapacity(), this) *
-                upgrade.getSpeed(getFuelSpeed(), this);
+                upgrade.getSpeed(getFuelSpeed(), this) * getThrottle();
 
         if (Mth.equal(stressBase, 0))
             return false;
@@ -228,8 +261,8 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     }
 
     @Override
-    public float getRemainingTicks() {
-        return remainingTicks;
+    public int getAnalogSignal() {
+        return analogSignal;
     }
 
     @Override

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
@@ -6,6 +6,7 @@ import com.jesz.createdieselgenerators.CDGConfig;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineSoundInstance;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineUpgrades;
 import com.jesz.createdieselgenerators.content.diesel_engine.IEngine;
+import com.jesz.createdieselgenerators.fuel_type.FuelType;
 import com.simibubi.create.api.equipment.goggles.IHaveGoggleInformation;
 import com.simibubi.create.content.contraptions.bearing.WindmillBearingBlockEntity;
 import com.simibubi.create.content.kinetics.base.IRotate;
@@ -36,6 +37,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 
@@ -53,6 +55,12 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     private boolean signalChanged = false;
     private float fuelDebt = 0f;
     boolean overStressed = false;
+    private FuelType cachedFuelType = FuelType.EMPTY;
+    private FluidStack lastCachedFluid = FluidStack.EMPTY;
+    private float cachedFuelSpeed = 0f;
+    private float cachedFuelCapacity = 0f;
+    private float cachedBurnRate = 0f;
+    private boolean needsShaftRegistration = true;
 
     public HugeDieselEngineBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -75,6 +83,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         fuelDebt = 0f;
         signalChanged = true;
         overStressed = tag.contains("OverStressed") && tag.getBoolean("OverStressed");
+        invalidateFuelCache();
     }
 
     @Override
@@ -92,8 +101,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         if (wasOverStressed && !overStressed)
             signalChanged = true;
 
-        if (!overStressed && enabled() && getThrottle() > 0 && shaft != null
-                && shaft.engines.stream().noneMatch(e -> e.getFirst().equals(worldPosition)))
+        if (!overStressed && enabled() && getThrottle() > 0 && needsShaftRegistration)
             signalChanged = true;
 
         if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
@@ -118,9 +126,11 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
                 shaft.update(worldPosition,
                         movementDirection.getValue() == 0 ? 1 : -1,
                         upgrade.getCapacity(getFuelCapacity(), this),
-                        upgrade.getSpeed(getFuelSpeed(), this) * throttle);
+                        cachedFuelSpeed * throttle);
+                needsShaftRegistration = false;
             } else if (shaft != null && getThrottle() == 0f) {
                 shaft.removeGenerator(worldPosition);
+                needsShaftRegistration = true;
             }
         }
 
@@ -131,14 +141,16 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         if (shaft == null)
             return;
 
-        if (enabled() && getThrottle() > 0 && !overStressed) {
-            if (shaft.movementDirection != 0 && shaft.movementDirection != (movementDirection.get() == WindmillBearingBlockEntity.RotationDirection.CLOCKWISE ? 1 : -1)) {
+        if (enabled() && getThrottle() > 0) {
+            if (shaft.movementDirection != 0 && shaft.movementDirection !=
+                    (movementDirection.get() == WindmillBearingBlockEntity.RotationDirection.CLOCKWISE ? 1 : -1)) {
                 shaft.removeGenerator(worldPosition);
+                needsShaftRegistration = true;
                 onDirectionChanged(movementDirection.getValue());
                 return;
             }
 
-            fuelDebt += getFuelBurnRate() * getFuelThrottle();
+            fuelDebt += cachedBurnRate * getFuelThrottle();
             while (fuelDebt >= 1f) {
                 tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
                 fuelDebt -= 1f;
@@ -146,8 +158,10 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
 
             if (level.isClientSide)
                 CatnipServices.PLATFORM.executeOnClientOnly(() -> this::tickClient);
-        } else if (!overStressed)
+        } else {
             shaft.removeGenerator(worldPosition);
+            needsShaftRegistration = true;
+        }
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -295,4 +309,15 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     public void setUpgrade(EngineUpgrades upgrade) {
         this.upgrade = upgrade;
     }
+
+    @Override public FuelType getCachedFuelType() { return cachedFuelType; }
+    @Override public void setCachedFuelType(FuelType t) { cachedFuelType = t; }
+    @Override public FluidStack getLastCachedFluid() { return lastCachedFluid; }
+    @Override public void setLastCachedFluid(FluidStack f) { lastCachedFluid = f; }
+    @Override public float getCachedFuelSpeed() { return cachedFuelSpeed; }
+    @Override public void setCachedFuelSpeed(float s) { cachedFuelSpeed = s; }
+    @Override public float getCachedFuelCapacity() { return cachedFuelCapacity; }
+    @Override public void setCachedFuelCapacity(float c) { cachedFuelCapacity = c; }
+    @Override public float getCachedBurnRate() { return cachedBurnRate; }
+    @Override public void setCachedBurnRate(float r) { cachedBurnRate = r; }
 }

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlockEntity.java
@@ -64,8 +64,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         super.write(tag, registries, clientPacket);
         tag.putString("Upgrade", upgrade.getId().toString());
         tag.putInt("AnalogSignal", analogSignal);
-        tag.putFloat("fuelDebt", fuelDebt);
-
+        tag.putBoolean("OverStressed", overStressed);
     }
 
     @Override
@@ -73,7 +72,9 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
         super.read(tag, registries, clientPacket);
         upgrade = EngineUpgrades.get(ResourceLocation.parse(tag.getString("Upgrade")));
         analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 0;
-        fuelDebt = tag.contains("fuelDebt") ? tag.getFloat("fuelDebt") : 0f;
+        fuelDebt = 0f;
+        signalChanged = true;
+        overStressed = tag.contains("OverStressed") && tag.getBoolean("OverStressed");
     }
 
     @Override
@@ -85,7 +86,15 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
     public void lazyTick() {
         super.lazyTick();
         PoweredEngineShaftBlockEntity shaft = getShaft();
+        boolean wasOverStressed = overStressed;
         overStressed = shaft != null && shaft.isOverStressed();
+
+        if (wasOverStressed && !overStressed)
+            signalChanged = true;
+
+        if (!overStressed && enabled() && getThrottle() > 0 && shaft != null
+                && shaft.engines.stream().noneMatch(e -> e.getFirst().equals(worldPosition)))
+            signalChanged = true;
 
         if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
         int power = level.getBestNeighborSignal(getBlockPos());
@@ -101,31 +110,33 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
 
         if (signalChanged) {
             signalChanged = false;
+            setChanged();
             sendData();
+            PoweredEngineShaftBlockEntity shaft = getShaft();
+            if (shaft != null && enabled() && getThrottle() > 0) {
+                float throttle = getThrottle();
+                shaft.update(worldPosition,
+                        movementDirection.getValue() == 0 ? 1 : -1,
+                        upgrade.getCapacity(getFuelCapacity(), this),
+                        upgrade.getSpeed(getFuelSpeed(), this) * throttle);
+            } else if (shaft != null && getThrottle() == 0f) {
+                shaft.removeGenerator(worldPosition);
+            }
         }
 
-        if (overStressed) {
-            PoweredEngineShaftBlockEntity shaft = getShaft();
-            if (shaft != null)
-                shaft.removeGenerator(worldPosition);
+        if (overStressed)
             return;
-        }
 
         PoweredEngineShaftBlockEntity shaft = getShaft();
         if (shaft == null)
             return;
 
-        if (enabled() && getThrottle() > 0) {
+        if (enabled() && getThrottle() > 0 && !overStressed) {
             if (shaft.movementDirection != 0 && shaft.movementDirection != (movementDirection.get() == WindmillBearingBlockEntity.RotationDirection.CLOCKWISE ? 1 : -1)) {
                 shaft.removeGenerator(worldPosition);
                 onDirectionChanged(movementDirection.getValue());
                 return;
             }
-
-            float throttle = getThrottle();
-            float speed = upgrade.getSpeed(getFuelSpeed(), this) * throttle;
-            float capacity = upgrade.getCapacity(getFuelCapacity(), this);
-            shaft.update(worldPosition, movementDirection.getValue() == 0 ? 1 : -1, capacity, speed);
 
             fuelDebt += getFuelBurnRate() * getFuelThrottle();
             while (fuelDebt >= 1f) {
@@ -135,7 +146,7 @@ public class HugeDieselEngineBlockEntity extends SmartBlockEntity implements IHa
 
             if (level.isClientSide)
                 CatnipServices.PLATFORM.executeOnClientOnly(() -> this::tickClient);
-        } else
+        } else if (!overStressed)
             shaft.removeGenerator(worldPosition);
     }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlock.java
@@ -83,6 +83,25 @@ public class ModularDieselEngineBlock extends HorizontalKineticBlock implements 
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos otherPos, boolean moving) {
         level.setBlockAndUpdate(pos, state.setValue(POWERED, level.hasNeighborSignal(pos)));
+
+        if (CDGConfig.ANALOG_SPEED_CONTROL.get()) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof ModularDieselEngineBlockEntity engine) {
+                ModularDieselEngineBlockEntity controller = engine.getControllerBE();
+                if (controller != null) {
+                    int maxSignal = 0;
+                    for (int i = 0; i < controller.getHeight(); i++) {
+                        BlockPos segPos = controller.getBlockPos().relative(
+                                controller.getBlockState().getValue(FACING).getAxis(), i);
+                        maxSignal = Math.max(maxSignal, level.getBestNeighborSignal(segPos));
+                    }
+                    if (maxSignal != controller.analogSignal) {
+                        controller.setAnalogSignal(maxSignal);
+                        controller.setSignalChanged(true);
+                    }
+                }
+            }
+        }
         super.neighborChanged(state, level, pos, block, otherPos, moving);
     }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -47,7 +47,6 @@ import static com.jesz.createdieselgenerators.content.diesel_engine.modular.Modu
 
 public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity implements IEngine, IMultiBlockEntityContainer.Fluid {
     protected ScrollOptionBehaviour<WindmillBearingBlockEntity.RotationDirection> movementDirection;
-    protected float remainingTicks = 0;
     protected int length = 1;
     @NotNull
     protected EngineUpgrades upgrade = EngineUpgrades.EMPTY;
@@ -59,10 +58,13 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
     protected boolean updateCapability = false;
     private float lastCapacity;
     private float lastSpeed;
+    public int analogSignal = 0;
+    private float fuelDebt = 0f;
 
 
     public ModularDieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
+        setLazyTickRate(10);
     }
 
     @Override
@@ -117,16 +119,23 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
     @Override
     public float calculateAddedStressCapacity() {
-        float capacity = upgrade.getCapacity(getFuelCapacity() * getHeight() * (1 / upgrade.getSpeed(getFuelSpeed(), this)) * getFuelSpeed(), this);
+        float speed = upgrade.getSpeed(getFuelSpeed(), this) * getThrottle();
+        float capacity = upgrade.getCapacity(
+                getFuelCapacity() * getHeight() * (1 / Math.max(speed, 0.001f)) * speed, this);
         lastCapacityProvided = capacity;
         return capacity;
     }
 
     @Override
     public float getGeneratedSpeed() {
-        if(!enabled() || !isController() || remainingTicks < 1)
-            return 0;
-        return convertToDirection((movementDirection.getValue() == 1 ? -1 : 1) * upgrade.getSpeed(getFuelSpeed(), this), getBlockState().getValue(ModularDieselEngineBlock.FACING));
+        if (!enabled() || !isController()) return 0;
+        float throttle = getThrottle();
+        if (throttle == 0f) return 0;
+        return convertToDirection(
+                (movementDirection.getValue() == 1 ? -1 : 1)
+                        * upgrade.getSpeed(getFuelSpeed(), this)
+                        * throttle,
+                getBlockState().getValue(ModularDieselEngineBlock.FACING));
     }
 
     @Override
@@ -153,20 +162,25 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
             return;
         }
-        float fuelCapacity = upgrade.getCapacity(getFuelCapacity() * getHeight() * (1 / upgrade.getSpeed(getFuelSpeed(), this)) * getFuelSpeed(), this);
+
+        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
+            return;
+
+        float throttle = getThrottle();
+        float fuelCapacity = upgrade.getCapacity(
+                getFuelCapacity() * getHeight() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
+                        * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
         if (!level.isClientSide && (lastSpeed != getGeneratedSpeed() || lastCapacity != fuelCapacity)) {
             reActivateSource = true;
             lastSpeed = getGeneratedSpeed();
             lastCapacity = fuelCapacity;
         }
         if (enabled()) {
-            if (remainingTicks < length + 1) {
-                remainingTicks += length / getFuelBurnRate();
+            fuelDebt += (length * getFuelBurnRate()) * getFuelThrottle();
+            while (fuelDebt >= 1f) {
                 tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
+                fuelDebt -= 1f;
             }
-
-            if (remainingTicks >= 0)
-                remainingTicks -= length;
         }
 
         if (level.isClientSide) {
@@ -179,8 +193,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
     @OnlyIn(Dist.CLIENT)
     protected void tickClient() {
-
-        if (enabled()) {
+        if (enabled() && getThrottle() > 0) {
             Vec3 pos = Vec3.atCenterOf(getBlockPos());
             if (getBlockState().getValue(FACING).getAxis() == Direction.Axis.X)
                 pos = pos.add((double) length / 2 - 0.5, 0, 0);
@@ -192,7 +205,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
                         .play(soundInstance = upgrade.createSoundInstance(this, pos));
             } else if (soundInstance.active()) {
                 soundInstance.keepAlive();
-                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch());
+                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch() * getThrottle());
                 soundInstance.setVolume(upgrade.getVolume(this));
             }
         } else {
@@ -219,11 +232,6 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         if (!isController())
             return;
         ConnectivityHandler.formMulti(this);
-    }
-
-    @Override
-    public float getRemainingTicks() {
-        return remainingTicks;
     }
 
     @Override
@@ -301,7 +309,6 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
         updateConnectivity = compound.contains("Uninitialized");
         upgrade = EngineUpgrades.get(ResourceLocation.parse(compound.getString("Upgrade")));
-        remainingTicks = compound.getFloat("remainingTicks");
         controller = null;
         lastKnownPos = null;
 
@@ -315,6 +322,8 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             tankInventory.readFromNBT(registries, compound.getCompound("TankContent"));
             if (tankInventory.getSpace() < 0)
                 tankInventory.drain(-tankInventory.getSpace(), IFluidHandler.FluidAction.EXECUTE);
+            analogSignal = compound.contains("AnalogSignal") ? compound.getInt("AnalogSignal") : 0;
+            fuelDebt = compound.contains("fuelDebt") ? compound.getFloat("fuelDebt") : 0f;
         }
 
         updateCapability = true;
@@ -344,9 +353,10 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             compound.put("Controller", NbtUtils.writeBlockPos(controller));
         if (isController()) {
             compound.putString("Upgrade", upgrade.getId().toString());
-            compound.putFloat("remainingTicks", remainingTicks);
             compound.put("TankContent", tankInventory.writeToNBT(registries, new CompoundTag()));
             compound.putInt("Height", length);
+            compound.putInt("AnalogSignal", analogSignal);
+            compound.putFloat("fuelDebt", fuelDebt);
         }
     }
 
@@ -405,6 +415,8 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
     public boolean enabled() {
         if (!IEngine.super.enabled())
             return false;
+        if (CDGConfig.ANALOG_SPEED_CONTROL.get())
+            return true;
         if (!CDGConfig.ENGINES_DISABLED_WITH_REDSTONE.get())
             return true;
         for (int i = 1; i < length; i++) {
@@ -414,6 +426,31 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
                     return false;
         }
         return true;
+    }
+
+    @Override
+    public int getAnalogSignal() {
+        return analogSignal;
+    }
+
+    @Override
+    public void lazyTick() {
+        super.lazyTick();
+        if (!isController()) return;
+
+        overStressed = isOverStressed();
+
+        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
+
+        int maxSignal = level.getBestNeighborSignal(getBlockPos());
+        for (int i = 1; i < length; i++) {
+            BlockPos segPos = getBlockPos().relative(getMainConnectionAxis(), i);
+            maxSignal = Math.max(maxSignal, level.getBestNeighborSignal(segPos));
+        }
+
+        if (maxSignal != analogSignal) {
+            analogSignal = maxSignal;
+        }
     }
 }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -71,7 +71,6 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
     public ModularDieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
-        setLazyTickRate(10);
     }
 
     @Override
@@ -168,6 +167,13 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             return;
         }
 
+        if (signalChanged) {
+            signalChanged = false;
+            reActivateSource = true;
+            setChanged();
+            sendData();
+        }
+
         boolean effectivelyOff = getThrottle() == 0f || !validFS();
         if (effectivelyOff) {
             if (hasNetwork())
@@ -177,11 +183,17 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             return;
         }
 
-        if (signalChanged) {
-            signalChanged = false;
-            reActivateSource = true;
-            setChanged();
-            sendData();
+        if (!level.isClientSide && validFS()) {
+            float throttle = getThrottle();
+            float currentSpeed = getGeneratedSpeed();
+            float currentCapacity = upgrade.getCapacity(
+                    getFuelCapacity() * getHeight() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
+                            * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
+            if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
+                reActivateSource = true;
+                lastSpeed = currentSpeed;
+                lastCapacity = currentCapacity;
+            }
         }
 
         if (isOverStressed())
@@ -443,38 +455,8 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         return analogSignal;
     }
 
-    @Override
-    public void lazyTick() {
-        super.lazyTick();
-        if (!isController()) return;
-
-        if (!level.isClientSide && validFS()) {
-            float throttle = getThrottle();
-            float currentSpeed = getGeneratedSpeed();
-            float currentCapacity = upgrade.getCapacity(
-                    getFuelCapacity() * getHeight() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
-                            * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
-            if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
-                reActivateSource = true;
-                lastSpeed = currentSpeed;
-                lastCapacity = currentCapacity;
-            }
-        }
-
-        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
-
-        int maxSignal = level.getBestNeighborSignal(getBlockPos());
-        for (int i = 1; i < length; i++) {
-            BlockPos segPos = getBlockPos().relative(getMainConnectionAxis(), i);
-            maxSignal = Math.max(maxSignal, level.getBestNeighborSignal(segPos));
-        }
-
-        if (maxSignal != analogSignal) {
-            analogSignal = maxSignal;
-            signalChanged = true;
-            setChanged();
-        }
-    }
+    public void setAnalogSignal(int newSignal) { analogSignal = newSignal; }
+    public void setSignalChanged(boolean newSignal) { signalChanged = newSignal; }
 
     @Override public FuelType getCachedFuelType() { return cachedFuelType; }
     @Override public void setCachedFuelType(FuelType t) { cachedFuelType = t; }

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -98,17 +98,15 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
     @Override
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
-        if (isController()) {
-            if (getGeneratedSpeed() == 0)
+        if (!isController()) {
+            ModularDieselEngineBlockEntity controller = getControllerBE();
+            if (controller == null)
                 return false;
-            super.addToGoggleTooltip(tooltip, isPlayerSneaking);
-            containedFluidTooltip(tooltip, isPlayerSneaking, fluidCapability);
-            return true;
+            return controller.addToGoggleTooltip(tooltip, isPlayerSneaking);
         }
-        ModularDieselEngineBlockEntity controller = getControllerBE();
-        if (controller == null)
-            return false;
-        return controller.addToGoggleTooltip(tooltip, isPlayerSneaking);
+        if (getGeneratedSpeed() != 0)
+            super.addToGoggleTooltip(tooltip, isPlayerSneaking);
+        return containedFluidTooltip(tooltip, isPlayerSneaking, fluidCapability);
     }
 
     public void onDirectionChanged(int v) {
@@ -189,12 +187,10 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         if (isOverStressed())
             return;
 
-        if (!isOverStressed()) {
-            fuelDebt += (length * cachedBurnRate) * getFuelThrottle();
-            while (fuelDebt >= 1f) {
-                tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
-                fuelDebt -= 1f;
-            }
+        fuelDebt += (length * cachedBurnRate) * getFuelThrottle();
+        while (fuelDebt >= 1f) {
+            tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
+            fuelDebt -= 1f;
         }
 
         if (level.isClientSide) {

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -60,7 +60,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
     private float lastSpeed;
     public int analogSignal = 0;
     private float fuelDebt = 0f;
-
+    private boolean signalChanged = false;
 
     public ModularDieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
@@ -163,7 +163,23 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             return;
         }
 
-        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
+        boolean effectivelyOff = getThrottle() == 0f || !validFS();
+        if (effectivelyOff) {
+            if (hasNetwork())
+                getOrCreateNetwork().remove(this);
+            detachKinetics();
+            removeSource();
+            return;
+        }
+
+        if (signalChanged) {
+            signalChanged = false;
+            reActivateSource = true;
+            setChanged();
+            sendData();
+        }
+
+        if (isOverStressed())
             return;
 
         float throttle = getThrottle();
@@ -175,7 +191,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             lastSpeed = getGeneratedSpeed();
             lastCapacity = fuelCapacity;
         }
-        if (enabled()) {
+        if (!isOverStressed()) {
             fuelDebt += (length * getFuelBurnRate()) * getFuelThrottle();
             while (fuelDebt >= 1f) {
                 tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
@@ -193,7 +209,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
     @OnlyIn(Dist.CLIENT)
     protected void tickClient() {
-        if (enabled() && getThrottle() > 0) {
+        if (enabled() && getThrottle() > 0 && !isOverStressed()) {
             Vec3 pos = Vec3.atCenterOf(getBlockPos());
             if (getBlockState().getValue(FACING).getAxis() == Direction.Axis.X)
                 pos = pos.add((double) length / 2 - 0.5, 0, 0);
@@ -323,7 +339,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             if (tankInventory.getSpace() < 0)
                 tankInventory.drain(-tankInventory.getSpace(), IFluidHandler.FluidAction.EXECUTE);
             analogSignal = compound.contains("AnalogSignal") ? compound.getInt("AnalogSignal") : 0;
-            fuelDebt = compound.contains("fuelDebt") ? compound.getFloat("fuelDebt") : 0f;
+            fuelDebt = 0f;
         }
 
         updateCapability = true;
@@ -356,7 +372,6 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             compound.put("TankContent", tankInventory.writeToNBT(registries, new CompoundTag()));
             compound.putInt("Height", length);
             compound.putInt("AnalogSignal", analogSignal);
-            compound.putFloat("fuelDebt", fuelDebt);
         }
     }
 
@@ -438,8 +453,6 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         super.lazyTick();
         if (!isController()) return;
 
-        overStressed = isOverStressed();
-
         if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
 
         int maxSignal = level.getBestNeighborSignal(getBlockPos());
@@ -450,6 +463,8 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
 
         if (maxSignal != analogSignal) {
             analogSignal = maxSignal;
+            signalChanged = true;
+            setChanged();
         }
     }
 }

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -7,6 +7,7 @@ import com.jesz.createdieselgenerators.content.diesel_engine.EngineSoundInstance
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineUpgrades;
 import com.jesz.createdieselgenerators.content.diesel_engine.IEngine;
 import com.jesz.createdieselgenerators.content.diesel_engine.normal.DieselEngineBlock;
+import com.jesz.createdieselgenerators.fuel_type.FuelType;
 import com.simibubi.create.api.connectivity.ConnectivityHandler;
 import com.simibubi.create.content.contraptions.bearing.WindmillBearingBlockEntity;
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
@@ -35,6 +36,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 import org.jetbrains.annotations.NotNull;
@@ -61,6 +63,11 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
     public int analogSignal = 0;
     private float fuelDebt = 0f;
     private boolean signalChanged = false;
+    private FuelType cachedFuelType = FuelType.EMPTY;
+    private FluidStack lastCachedFluid = FluidStack.EMPTY;
+    private float cachedFuelSpeed = 0f;
+    private float cachedFuelCapacity = 0f;
+    private float cachedBurnRate = 0f;
 
     public ModularDieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
@@ -182,17 +189,8 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         if (isOverStressed())
             return;
 
-        float throttle = getThrottle();
-        float fuelCapacity = upgrade.getCapacity(
-                getFuelCapacity() * getHeight() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
-                        * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
-        if (!level.isClientSide && (lastSpeed != getGeneratedSpeed() || lastCapacity != fuelCapacity)) {
-            reActivateSource = true;
-            lastSpeed = getGeneratedSpeed();
-            lastCapacity = fuelCapacity;
-        }
         if (!isOverStressed()) {
-            fuelDebt += (length * getFuelBurnRate()) * getFuelThrottle();
+            fuelDebt += (length * cachedBurnRate) * getFuelThrottle();
             while (fuelDebt >= 1f) {
                 tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
                 fuelDebt -= 1f;
@@ -340,6 +338,7 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
                 tankInventory.drain(-tankInventory.getSpace(), IFluidHandler.FluidAction.EXECUTE);
             analogSignal = compound.contains("AnalogSignal") ? compound.getInt("AnalogSignal") : 0;
             fuelDebt = 0f;
+            invalidateFuelCache();
         }
 
         updateCapability = true;
@@ -453,6 +452,19 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
         super.lazyTick();
         if (!isController()) return;
 
+        if (!level.isClientSide && validFS()) {
+            float throttle = getThrottle();
+            float currentSpeed = getGeneratedSpeed();
+            float currentCapacity = upgrade.getCapacity(
+                    getFuelCapacity() * getHeight() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
+                            * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
+            if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
+                reActivateSource = true;
+                lastSpeed = currentSpeed;
+                lastCapacity = currentCapacity;
+            }
+        }
+
         if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
 
         int maxSignal = level.getBestNeighborSignal(getBlockPos());
@@ -467,5 +479,16 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             setChanged();
         }
     }
+
+    @Override public FuelType getCachedFuelType() { return cachedFuelType; }
+    @Override public void setCachedFuelType(FuelType t) { cachedFuelType = t; }
+    @Override public FluidStack getLastCachedFluid() { return lastCachedFluid; }
+    @Override public void setLastCachedFluid(FluidStack f) { lastCachedFluid = f; }
+    @Override public float getCachedFuelSpeed() { return cachedFuelSpeed; }
+    @Override public void setCachedFuelSpeed(float s) { cachedFuelSpeed = s; }
+    @Override public float getCachedFuelCapacity() { return cachedFuelCapacity; }
+    @Override public void setCachedFuelCapacity(float c) { cachedFuelCapacity = c; }
+    @Override public float getCachedBurnRate() { return cachedBurnRate; }
+    @Override public void setCachedBurnRate(float r) { cachedBurnRate = r; }
 }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlock.java
@@ -113,7 +113,18 @@ public class DieselEngineBlock extends DirectionalKineticBlock implements Specia
 
     @Override
     public void neighborChanged(BlockState state, Level level, BlockPos pos, Block block, BlockPos otherPos, boolean moving) {
-        level.setBlock(pos, state.setValue(POWERED, level.hasNeighborSignal(pos)), 2);
+        boolean powered = level.hasNeighborSignal(pos);
+
+        if (state.getValue(POWERED) != powered) {
+            level.setBlock(pos, state.setValue(POWERED, powered), 2);
+        }
+
+        BlockEntity be = level.getBlockEntity(pos);
+        if (be instanceof DieselEngineBlockEntity engine) {
+            engine.setAnalogSignal(level.getBestNeighborSignal(pos));
+            engine.setSignalChanged(true);
+        }
+
         super.neighborChanged(state, level, pos, block, otherPos, moving);
     }
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -153,9 +153,8 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
     @Override
     public boolean addToGoggleTooltip(List<Component> tooltip, boolean isPlayerSneaking) {
-        if (getGeneratedSpeed() == 0)
-            return false;
-        super.addToGoggleTooltip(tooltip, isPlayerSneaking);
+        if (getGeneratedSpeed() != 0)
+            super.addToGoggleTooltip(tooltip, isPlayerSneaking);
         containedFluidTooltip(tooltip, isPlayerSneaking, tank.getCapability());
         return true;
     }

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -58,7 +58,10 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
                         return be.tank.getCapability();
                     Direction facing = be.getBlockState().getValue(FACING);
                     if (facing.getAxis().isVertical()) {
-                        if (side.getAxis() == (facing == Direction.UP ? Direction.Axis.X : Direction.Axis.Z))
+                        Direction.Axis portAxis = (facing == Direction.DOWN)
+                                ? Direction.Axis.X
+                                : Direction.Axis.Z;
+                        if (side.getAxis() == portAxis)
                             return be.tank.getCapability();
                     } else {
                         if (side == Direction.DOWN)

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -1,6 +1,7 @@
 package com.jesz.createdieselgenerators.content.diesel_engine.normal;
 
 import com.jesz.createdieselgenerators.CDGBlockEntityTypes;
+import com.jesz.createdieselgenerators.CDGConfig;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineSoundInstance;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineUpgrades;
 import com.jesz.createdieselgenerators.content.diesel_engine.IEngine;
@@ -41,9 +42,13 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     SmartFluidTankBehaviour tank;
     private float lastCapacity;
     private float lastSpeed;
+    private int analogSignal = 15;
+    private boolean signalChanged = false;
+    private float fuelDebt = 0f;
 
     public DieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
+        setLazyTickRate(10);
     }
 
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
@@ -70,6 +75,7 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
         tag.putFloat("RemainingTicks", remainingTicks);
         tag.putString("Upgrade", upgrade.getId().toString());
+        tag.putInt("AnalogSignal", analogSignal);
     }
 
     @Override
@@ -78,6 +84,8 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
         remainingTicks = tag.getFloat("RemainingTicks");
         upgrade = EngineUpgrades.get(ResourceLocation.parse(tag.getString("Upgrade")));
+        analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 15;
+        fuelDebt = 0f;
     }
 
     @Override
@@ -93,16 +101,34 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
     @Override
     public float calculateAddedStressCapacity() {
-        float capacity = upgrade.getCapacity(getFuelCapacity() * (1 / upgrade.getSpeed(getFuelSpeed(), this)) * getFuelSpeed(), this);
+        float speed = upgrade.getSpeed(getFuelSpeed(), this) * getThrottle();
+        float capacity = upgrade.getCapacity(getFuelCapacity() * (1 / Math.max(speed, 0.001f)) * speed, this);
         lastCapacityProvided = capacity;
         return capacity;
     }
 
     @Override
+    public void lazyTick() {
+        super.lazyTick();
+
+        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
+        int power = level.getBestNeighborSignal(getBlockPos());
+        if (power != analogSignal) {
+            analogSignal = power;
+            signalChanged = true;
+        }
+    }
+
+    @Override
     public float getGeneratedSpeed() {
-        if (!enabled())
-            return 0;
-        return convertToDirection((movementDirection.getValue() == 1 ? -1 : 1) * upgrade.getSpeed(getFuelSpeed(), this), getBlockState().getValue(FACING));
+        if (!enabled()) return 0;
+        float throttle = getThrottle();
+        if (throttle == 0f) return 0;
+        return convertToDirection(
+                (movementDirection.getValue() == 1 ? -1 : 1)
+                        * upgrade.getSpeed(getFuelSpeed(), this)
+                        * throttle,
+                getBlockState().getValue(FACING));
     }
 
     @Override
@@ -118,7 +144,19 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     public void tick() {
         super.tick();
 
-        float fuelCapacity = upgrade.getCapacity(getFuelCapacity() * (1 / upgrade.getSpeed(getFuelSpeed(), this)) * getFuelSpeed(), this);
+        if (signalChanged) {
+            signalChanged = false;
+            reActivateSource = true;
+            sendData();
+        }
+
+        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
+            return;
+
+        float throttle = getThrottle();
+        float fuelCapacity = upgrade.getCapacity(
+                getFuelCapacity() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
+                        * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
         if (!level.isClientSide && (lastSpeed != getGeneratedSpeed() || lastCapacity != fuelCapacity)) {
             reActivateSource = true;
             lastSpeed = getGeneratedSpeed();
@@ -126,18 +164,15 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
         }
 
         if (enabled()) {
-            if (remainingTicks < 2) {
-                remainingTicks += 1 / getFuelBurnRate();
+            fuelDebt += getFuelBurnRate() * getFuelThrottle();
+            while (fuelDebt >= 1f) {
                 tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
+                fuelDebt -= 1f;
             }
-
-            if (remainingTicks >= 0)
-                remainingTicks--;
         }
 
-        if (level.isClientSide) {
+        if (level.isClientSide)
             CatnipServices.PLATFORM.executeOnClientOnly(() -> this::tickClient);
-        }
     }
 
     @OnlyIn(Dist.CLIENT)
@@ -145,14 +180,14 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
     @OnlyIn(Dist.CLIENT)
     protected void tickClient() {
-        if (enabled()) {
+        if (enabled() && getThrottle() > 0) {
             if (soundInstance == null || soundInstance.isStopped()) {
                 Minecraft.getInstance()
                         .getSoundManager()
                         .play(soundInstance = upgrade.createSoundInstance(this, Vec3.atCenterOf(getBlockPos())));
             } else if (soundInstance.active()) {
                 soundInstance.keepAlive();
-                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch());
+                soundInstance.setPitch(upgrade.getPitchMultiplier(this) * getFuelSoundPitch() * getThrottle());
                 soundInstance.setVolume(upgrade.getVolume(this));
             }
         } else {
@@ -164,8 +199,8 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     }
 
     @Override
-    public float getRemainingTicks() {
-        return remainingTicks;
+    public int getAnalogSignal() {
+        return analogSignal;
     }
 
     @Override

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -37,7 +37,6 @@ import static com.jesz.createdieselgenerators.content.diesel_engine.normal.Diese
 public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implements IEngine {
     ScrollOptionBehaviour<WindmillBearingBlockEntity.RotationDirection> movementDirection;
 
-    float remainingTicks = 0;
     EngineUpgrades upgrade = EngineUpgrades.EMPTY;
     SmartFluidTankBehaviour tank;
     private float lastCapacity;
@@ -72,8 +71,6 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     @Override
     protected void write(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.write(tag, registries, clientPacket);
-
-        tag.putFloat("RemainingTicks", remainingTicks);
         tag.putString("Upgrade", upgrade.getId().toString());
         tag.putInt("AnalogSignal", analogSignal);
     }
@@ -81,8 +78,6 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     @Override
     protected void read(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(tag, registries, clientPacket);
-
-        remainingTicks = tag.getFloat("RemainingTicks");
         upgrade = EngineUpgrades.get(ResourceLocation.parse(tag.getString("Upgrade")));
         analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 15;
         fuelDebt = 0f;
@@ -116,6 +111,7 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
         if (power != analogSignal) {
             analogSignal = power;
             signalChanged = true;
+            setChanged();
         }
     }
 
@@ -147,11 +143,18 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
         if (signalChanged) {
             signalChanged = false;
             reActivateSource = true;
+            setChanged();
             sendData();
         }
 
-        if (self() instanceof GeneratingKineticBlockEntity gkbe && gkbe.isOverStressed())
+        boolean effectivelyOff = getThrottle() == 0f || !validFS();
+        if (effectivelyOff) {
+            if (hasNetwork())
+                getOrCreateNetwork().remove(this);
+            detachKinetics();
+            removeSource();
             return;
+        }
 
         float throttle = getThrottle();
         float fuelCapacity = upgrade.getCapacity(
@@ -163,7 +166,7 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
             lastCapacity = fuelCapacity;
         }
 
-        if (enabled()) {
+        if (enabled() && !isOverStressed()) {
             fuelDebt += getFuelBurnRate() * getFuelThrottle();
             while (fuelDebt >= 1f) {
                 tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
@@ -180,7 +183,7 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
     @OnlyIn(Dist.CLIENT)
     protected void tickClient() {
-        if (enabled() && getThrottle() > 0) {
+        if (enabled() && getThrottle() > 0 && !isOverStressed()) {
             if (soundInstance == null || soundInstance.isStopped()) {
                 Minecraft.getInstance()
                         .getSoundManager()

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -54,7 +54,6 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
 
     public DieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
-        setLazyTickRate(10);
     }
 
     public static void registerCapabilities(RegisterCapabilitiesEvent event) {
@@ -114,32 +113,6 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     }
 
     @Override
-    public void lazyTick() {
-        super.lazyTick();
-
-        if (!level.isClientSide && validFS()) {
-            float throttle = getThrottle();
-            float currentSpeed = getGeneratedSpeed();
-            float currentCapacity = upgrade.getCapacity(
-                    getFuelCapacity() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
-                            * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
-            if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
-                reActivateSource = true;
-                lastSpeed = currentSpeed;
-                lastCapacity = currentCapacity;
-            }
-        }
-
-        if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
-        int power = level.getBestNeighborSignal(getBlockPos());
-        if (power != analogSignal) {
-            analogSignal = power;
-            signalChanged = true;
-            setChanged();
-        }
-    }
-
-    @Override
     public float getGeneratedSpeed() {
         if (!enabled()) return 0;
         float throttle = getThrottle();
@@ -168,6 +141,26 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
             reActivateSource = true;
             setChanged();
             sendData();
+        }
+
+        if (!level.isClientSide && validFS()) {
+            float throttle = getThrottle();
+
+            if (throttle != 0f || lastSpeed != 0f) {
+                float currentSpeed = getGeneratedSpeed();
+
+                float baseSpeed = upgrade.getSpeed(getFuelSpeed(), this) * throttle;
+                float currentCapacity = upgrade.getCapacity(
+                        getFuelCapacity() * (1 / Math.max(baseSpeed, 0.001f)) * baseSpeed,
+                        this
+                );
+
+                if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
+                    reActivateSource = true;
+                    lastSpeed = currentSpeed;
+                    lastCapacity = currentCapacity;
+                }
+            }
         }
 
         boolean effectivelyOff = getThrottle() == 0f || !validFS();
@@ -213,6 +206,9 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
             }
         }
     }
+
+    public void setAnalogSignal(int newSignal) { analogSignal = newSignal; }
+    public void setSignalChanged(boolean newSignal) { signalChanged = newSignal; }
 
     @Override
     public int getAnalogSignal() {

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlockEntity.java
@@ -5,6 +5,7 @@ import com.jesz.createdieselgenerators.CDGConfig;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineSoundInstance;
 import com.jesz.createdieselgenerators.content.diesel_engine.EngineUpgrades;
 import com.jesz.createdieselgenerators.content.diesel_engine.IEngine;
+import com.jesz.createdieselgenerators.fuel_type.FuelType;
 import com.simibubi.create.content.contraptions.bearing.WindmillBearingBlockEntity;
 import com.simibubi.create.content.kinetics.base.GeneratingKineticBlockEntity;
 import com.simibubi.create.foundation.blockEntity.SmartBlockEntity;
@@ -27,6 +28,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.api.distmarker.OnlyIn;
 import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.capabilities.RegisterCapabilitiesEvent;
+import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import net.neoforged.neoforge.fluids.capability.templates.FluidTank;
 
@@ -44,6 +46,11 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     private int analogSignal = 15;
     private boolean signalChanged = false;
     private float fuelDebt = 0f;
+    private FuelType cachedFuelType = FuelType.EMPTY;
+    private FluidStack lastCachedFluid = FluidStack.EMPTY;
+    private float cachedFuelSpeed = 0f;
+    private float cachedFuelCapacity = 0f;
+    private float cachedBurnRate = 0f;
 
     public DieselEngineBlockEntity(BlockEntityType<?> typeIn, BlockPos pos, BlockState state) {
         super(typeIn, pos, state);
@@ -82,8 +89,9 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     protected void read(CompoundTag tag, HolderLookup.Provider registries, boolean clientPacket) {
         super.read(tag, registries, clientPacket);
         upgrade = EngineUpgrades.get(ResourceLocation.parse(tag.getString("Upgrade")));
-        analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 15;
+        analogSignal = tag.contains("AnalogSignal") ? tag.getInt("AnalogSignal") : 0;
         fuelDebt = 0f;
+        invalidateFuelCache();
     }
 
     @Override
@@ -108,6 +116,19 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     @Override
     public void lazyTick() {
         super.lazyTick();
+
+        if (!level.isClientSide && validFS()) {
+            float throttle = getThrottle();
+            float currentSpeed = getGeneratedSpeed();
+            float currentCapacity = upgrade.getCapacity(
+                    getFuelCapacity() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
+                            * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
+            if (lastSpeed != currentSpeed || lastCapacity != currentCapacity) {
+                reActivateSource = true;
+                lastSpeed = currentSpeed;
+                lastCapacity = currentCapacity;
+            }
+        }
 
         if (!CDGConfig.ANALOG_SPEED_CONTROL.get()) return;
         int power = level.getBestNeighborSignal(getBlockPos());
@@ -159,18 +180,8 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
             return;
         }
 
-        float throttle = getThrottle();
-        float fuelCapacity = upgrade.getCapacity(
-                getFuelCapacity() * (1 / Math.max(upgrade.getSpeed(getFuelSpeed(), this) * throttle, 0.001f))
-                        * upgrade.getSpeed(getFuelSpeed(), this) * throttle, this);
-        if (!level.isClientSide && (lastSpeed != getGeneratedSpeed() || lastCapacity != fuelCapacity)) {
-            reActivateSource = true;
-            lastSpeed = getGeneratedSpeed();
-            lastCapacity = fuelCapacity;
-        }
-
         if (enabled() && !isOverStressed()) {
-            fuelDebt += getFuelBurnRate() * getFuelThrottle();
+            fuelDebt += cachedBurnRate * getFuelThrottle();
             while (fuelDebt >= 1f) {
                 tank.getPrimaryHandler().drain(1, IFluidHandler.FluidAction.EXECUTE);
                 fuelDebt -= 1f;
@@ -228,4 +239,15 @@ public class DieselEngineBlockEntity extends GeneratingKineticBlockEntity implem
     public void setUpgrade(EngineUpgrades upgrade) {
         this.upgrade = upgrade;
     }
+
+    @Override public FuelType getCachedFuelType() { return cachedFuelType; }
+    @Override public void setCachedFuelType(FuelType t) { cachedFuelType = t; }
+    @Override public FluidStack getLastCachedFluid() { return lastCachedFluid; }
+    @Override public void setLastCachedFluid(FluidStack f) { lastCachedFluid = f; }
+    @Override public float getCachedFuelSpeed() { return cachedFuelSpeed; }
+    @Override public void setCachedFuelSpeed(float s) { cachedFuelSpeed = s; }
+    @Override public float getCachedFuelCapacity() { return cachedFuelCapacity; }
+    @Override public void setCachedFuelCapacity(float c) { cachedFuelCapacity = c; }
+    @Override public float getCachedBurnRate() { return cachedBurnRate; }
+    @Override public void setCachedBurnRate(float r) { cachedBurnRate = r; }
 }


### PR DESCRIPTION
Engines are now controllable by an `Analog Lever` - max level turns them off, 1 - 14 controls `throttle`.
Enabled by default in config. At lowest `throttle` 25% of normal fuel consumption is used, scales linearly to normal usage.
Sounds is lowered at lower `throttle` levels. 

General cleanup of engine related code.

Resolves #255.

Engines no longer consume fuel, animate or play sounds when connected to a overstressed network, fixes #285.

Vertical diesel engines take fuel from the sides, fixes #287/#281.

Also seems to have fixed #293 during the stall/fuel logic rework.