### PR TITLE
fix: Engine upgrade dupe

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/huge/HugeDieselEngineBlock.java
@@ -189,7 +189,7 @@ public class HugeDieselEngineBlock extends Block implements IBE<HugeDieselEngine
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (!state.is(newState.getBlock())) {
+        if (!state.is(newState.getBlock()) && !isMoving) {
             withBlockEntityDo(level, pos, be -> {
                 if (be.upgrade != EngineUpgrades.EMPTY)
                     popResource(level, pos, be.upgrade.getItem());

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlock.java
@@ -187,7 +187,7 @@ public class ModularDieselEngineBlock extends HorizontalKineticBlock implements 
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (!state.is(newState.getBlock()))
+        if (!state.is(newState.getBlock()) && !isMoving)
             withBlockEntityDo(level, pos, be -> {
                 if (be.upgrade != EngineUpgrades.EMPTY)
                     popResource(level, pos, be.upgrade.getItem());

--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/normal/DieselEngineBlock.java
@@ -231,7 +231,7 @@ public class DieselEngineBlock extends DirectionalKineticBlock implements Specia
 
     @Override
     public void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean isMoving) {
-        if (!state.is(newState.getBlock()))
+        if (!state.is(newState.getBlock())&& !isMoving)
             withBlockEntityDo(level, pos, be -> {
                 if (be.upgrade != EngineUpgrades.EMPTY)
                     popResource(level, pos, be.upgrade.getItem());


### PR DESCRIPTION
Add isMoving() check before popping off upgrade to prevent dupe when assembled/disassembled on Sable sublevels.
Fixes #286.