### PR TITLE
Fix redstone acid compat recipe still using forge tag namespace

### DIFF
--- a/src/main/resources/data/createdieselgenerators/recipe/compat/immersiveengineering/redstone_acid.json
+++ b/src/main/resources/data/createdieselgenerators/recipe/compat/immersiveengineering/redstone_acid.json
@@ -7,7 +7,7 @@
       "amount": 250
     },
     {
-      "tag": "forge:dusts/redstone"
+      "tag": "c:dusts/redstone"
     }
   ],
   "processingTime": 400,


### PR DESCRIPTION
change the tag used in the recipe from "forge:dusts/redstone" to "c:dusts/redstone".