### PR TITLE
Implement fix for improved ignition for chemical sprayer

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/tools/ChemicalSprayerProjectileEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/tools/ChemicalSprayerProjectileEntity.java
@@ -214,8 +214,11 @@ public class ChemicalSprayerProjectileEntity extends AbstractHurtingProjectile {
             level().playLocalSound(position().x, position().y, position().z, SoundEvents.FIRE_EXTINGUISH, SoundSource.BLOCKS, 0.5f, 2, true);
         }
 
-        if (fire && level().isEmptyBlock(facePos))
-            level().setBlockAndUpdate(facePos, BaseFireBlock.getState(level(), facePos));
+        if (fire && level().getBlockState(facePos).canBeReplaced() && level().getFluidState(facePos).isEmpty()) {
+            if (BaseFireBlock.canBePlacedAt(level(), facePos, hit.getDirection())) {
+                level().setBlockAndUpdate(facePos, BaseFireBlock.getState(level(), facePos));
+            }
+        }
 
         remove(RemovalReason.DISCARDED);
     }


### PR DESCRIPTION
Improved the ignition logic for the Chemical Sprayer to align more closely with vanilla fire placement rules. 

### Changes:
- Replaced the simple `isEmptyBlock` check with `BaseFireBlock.canBePlacedAt` to allow igniting the sides of flammable blocks.
- Added checks for `canBeReplaced()` and fluid presence, allowing fire to be placed in blocks containing grass, flowers, or other replaceable non-fluids.
- Verified that it correctly places soul fire when applicable, at least from testing.

### Impact:
The sprayer now feels more responsive and behaves consistently with other ignition sources (like Flint and Steel) in various environments.

Closes #322