### PR TITLE
Fix fuel burn rate for modular diesel engines scaling incorrectly

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/diesel_engine/modular/ModularDieselEngineBlockEntity.java
@@ -202,9 +202,9 @@ public class ModularDieselEngineBlockEntity extends GeneratingKineticBlockEntity
             return;
 
         fuelDebt += (length * cachedBurnRate) * getFuelThrottle();
-        while (fuelDebt >= 1f) {
+        while (fuelDebt >= length) {
             tankInventory.drain(length, IFluidHandler.FluidAction.EXECUTE);
-            fuelDebt -= 1f;
+            fuelDebt -= length;
         }
 
         if (level.isClientSide) {


### PR DESCRIPTION
Fixed a logic error in the fuel consumption calculation for modular Diesel Generators that caused fuel debt to scale quadratically with length rather than linearly.

### Changes:
- Adjusted the `fuelDebt` threshold in the consumption loop from `1f` to `length`.
- Adjusted the `fuelDebt` subtraction to `length` to match the amount drained from the tank inventory.
- Should also reduce performance impact?

### Impact:
Previously, because the code drained `length` amount of fluid every time `1f` of debt was reached (while debt was accumulated at a rate of `length * burnRate`), the total consumption effectively became length squared ($length^2$). This fix ensures that consumption scales linearly, making large modular generators as efficient as multiple single-block units.

Closes #327