### PR TITLE
fix: Use float comparison for burner heat value

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/burner/BurnerBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/burner/BurnerBlockEntity.java
@@ -151,13 +151,13 @@ public class BurnerBlockEntity extends KineticBlockEntity {
     }
 
     public BlazeBurnerBlock.HeatLevel calculateHeatLevel(float heat) {
-        if(heat >= 1.8)
+        if(heat >= 1.8f)
             return BlazeBurnerBlock.HeatLevel.SEETHING;
-        if(heat >= 1.4)
+        if(heat >= 1.4f)
             return BlazeBurnerBlock.HeatLevel.KINDLED;
-        if(heat >= 1.2)
+        if(heat >= 1.2f)
             return BlazeBurnerBlock.HeatLevel.FADING;
-        if(heat >= 1)
+        if(heat >= 1f)
             return BlazeBurnerBlock.HeatLevel.SMOULDERING;
         return BlazeBurnerBlock.HeatLevel.NONE;
     }


### PR DESCRIPTION
Fixes an issue where burner fuels that produce heat values exactly at some thresholds will instead still be in the lower range.

Specifically, Ethanol at max burn rate produces a heat value of 1.8, which should be Seething, but is instead just Kindling.

Original commit description:

> Doubles and floats aren't as comparable as sanity would like. For example, 1.8f < 1.8d.