### PR TITLE
bigger distillation tank means bigger output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ eclipse
 run
 runs
 run-data
+.vscode
 
 repo
 

--- a/src/main/java/com/jesz/createdieselgenerators/content/distillation/DistillationTankBlockEntity.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/distillation/DistillationTankBlockEntity.java
@@ -80,6 +80,7 @@ public class DistillationTankBlockEntity extends SmartBlockEntity implements IMu
     // For rendering purposes only
     private LerpedFloat fluidLevel;
     BlazeBurnerBlock.HeatLevel highestHeatLevel = BlazeBurnerBlock.HeatLevel.NONE;
+    int numberOfHighestHeat = 0;
 
     public DistillationTankBlockEntity(BlockEntityType<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -108,6 +109,23 @@ public class DistillationTankBlockEntity extends SmartBlockEntity implements IMu
             }
         }
         return highestHeat;
+    }
+
+    // counts the number of burners if an EXACT heat level
+    public int getNumberOfHeat(BlazeBurnerBlock.HeatLevel heatTest) {
+        int width = getControllerBE().width;
+        int heatCount = 0;
+
+        for (int xOffset = 0; xOffset < width; xOffset++) {
+            for (int zOffset = 0; zOffset < width; zOffset++) {
+                BlockPos pos = getController().offset(xOffset, -1, zOffset);
+                BlockState blockState = level.getBlockState(pos);
+                BlazeBurnerBlock.HeatLevel heat = BasinBlockEntity.getHeatLevelOf(blockState);
+                if(heatTest == heat)
+                    heatCount++;
+            }
+        }
+        return heatCount;
     }
 
     public void updateConnectivity() {
@@ -179,21 +197,24 @@ public class DistillationTankBlockEntity extends SmartBlockEntity implements IMu
                             SoundSource.BLOCKS, 0.05f, 0.5f);
                 }
 
-                if (tankInventory.getFluid().getAmount() >= currentRecipe.getFluidIngredients().get(0).amount()) {
-                    if (currentRecipe.getRequiredHeat().testBlazeBurner(highestHeatLevel)) {
-                        tankInventory.drain(currentRecipe.getFluidIngredients().get(0).amount(), IFluidHandler.FluidAction.EXECUTE);
-                        if (currentRecipe != null)
-                            for (int i = 0; i < currentRecipe.getFluidResults().size(); i++) {
-                                if (!(level.getBlockEntity(getBlockPos().above(i + 1)) instanceof DistillationTankBlockEntity be))
-                                    break;
+                if (currentRecipe.getRequiredHeat().testBlazeBurner(highestHeatLevel)) {
+                    for (int j = 0; j < numberOfHighestHeat; j++)
+                    {
+                        if (tankInventory.getFluid().getAmount() >= currentRecipe.getFluidIngredients().get(0).amount()) {
+                            tankInventory.drain(currentRecipe.getFluidIngredients().get(0).amount(), IFluidHandler.FluidAction.EXECUTE);
+                            if (currentRecipe != null)
+                                for (int i = 0; i < currentRecipe.getFluidResults().size(); i++) {
+                                    if (!(level.getBlockEntity(getBlockPos().above(i + 1)) instanceof DistillationTankBlockEntity be))
+                                        break;
 
-                                if (!isSameMultiBlock(be))
-                                    break;
-                                be.tankInventory.fill(currentRecipe.getFluidResults().get(i), IFluidHandler.FluidAction.EXECUTE);
-                            }
+                                    if (!isSameMultiBlock(be))
+                                        break;
+                                    be.tankInventory.fill(currentRecipe.getFluidResults().get(i), IFluidHandler.FluidAction.EXECUTE);
+                                }
+                        } else {
+                            tanksFull = true;
+                        }
                     }
-                } else {
-                    tanksFull = true;
                 }
 
                 currentRecipe = null;
@@ -808,6 +829,7 @@ public class DistillationTankBlockEntity extends SmartBlockEntity implements IMu
             return;
         if (isController()) {
             highestHeatLevel = getHeat();
+            numberOfHighestHeat = getNumberOfHeat(highestHeatLevel);
             sendData();
             onFluidStackChanged(tankInventory.getFluid());
             return;


### PR DESCRIPTION
Great mod btw! 

Sorry for just jumping in, but I just had a small change that I think will improve player's experience.

Sometimes when using this mod people make big 3x3 distillation towers thinking that the bigger tower will be more efficient or lead to more output than a 1x1 tower. The issue is in reality they produce exactly same amount at exactly the same rate. Ironically, a 3x3 tower is actually worse then a 1x1 tower because it takes up more space, more resources, and offers no extra reward.

This is not only confusing to players and causes them to waste resources, but I also cannot find it documented anywhere that this is a feature.

I propose to give bigger distillation a boost.

I know making bigger tanks process oil faster was considered, but the extremely short times did not feel natural. Instead, I propose that instead of bigger tanks processing recipes faster, they process more fluids in bulk. This way the rate can effectively be increased by 9x while keeping the timing of distilation exactly the same.

I made some slight changes to the logic so that when the heat is updated, a tally is kept of the number of blaze burners that match that heat level. When a recipe is finished, it processes that recipe the number of times there is a burner under it that matches that heat level. It is not actually a multipler. It really just processes the same recipe multiple times, so theoretically is the tanks fill up or there is not enough fluid to process, it will only do what it can.

The following behavior is implimented.

- a 1x1 tank with 1 heated blaze burner produces 1x heated recipe
- a 3x3 tank with 9 heated blaze burners produces 9x heated recipe
- a 3x3 tank with 1 heated blaze burners produces 1x heated recipe
- a 3x3 tank with 9 super-heated blaze burners produces 9x super-heated recipe
- a 3x3 tank with 1 super-heated blaze burners and 8 heated blaze burners produces 1x super-heated recipe

Only the number of burners matching the max is considered.

This should not change existing 1x1 distilation setups. After this change, the tradeoff between a 3x3 tower and a 1x1 tower will just be a matter of how you like to lay out your pipes and whether you like bulk quantities.

I hope you like this modification. If you have any questions or need me to fix anything, let me know.
Keep up the great work!