### PR TITLE
Fix Stockpile Switch target display for Distillation Towers

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/distillation/DistillationTankBlock.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/distillation/DistillationTankBlock.java
@@ -18,6 +18,7 @@ import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.BlockGetter;
@@ -134,6 +135,11 @@ public class DistillationTankBlock extends Block implements IBE<DistillationTank
             world.removeBlockEntity(pos);
             ConnectivityHandler.splitMulti(tankBE);
         }
+    }
+
+    @Override
+    public Item asItem() {
+        return AllBlocks.FLUID_TANK.asItem();
     }
 
     @Override


### PR DESCRIPTION
## Summary

- Use Create's Fluid Tank item as the item representation of a Distillation Tank.
- Fix the barrier icon and misleading "Not attached to a block" tooltip in the Stockpile Switch GUI.
- Keep the existing fluid detection and Redstone behavior unchanged.

## Rationale

This mirrors Create's native boiler behavior.

Boilers are assembled from Fluid Tanks and continue to appear as Fluid Tanks in the Stockpile Switch GUI. Distillation Towers are also converted from Create Fluid Tanks, so representing them with the same Fluid Tank item is consistent with Create's existing UI behavior.

It also avoids registering a directly placeable Distillation Tank item and is consistent with the existing `getCloneItemStack` behavior.

## Testing

Manually tested with:

- 1x1x3 Distillation Tower
- 2x2x3 Distillation Tower
- 3x3x3 Distillation Tower
- Stockpile Switches attached to every layer
- Fluid thresholds and Redstone output
- A compiled test JAR in a regular NeoForge client

Also verified with:

```text
./gradlew build
```

Fixes #383
