### PR TITLE
Added null checks to the BulkFermenterInventoryWrapper

### DIFF
--- a/src/main/java/com/jesz/createdieselgenerators/content/bulk_fermenter/BulkFermenterInventoryWrapper.java
+++ b/src/main/java/com/jesz/createdieselgenerators/content/bulk_fermenter/BulkFermenterInventoryWrapper.java
@@ -12,36 +12,46 @@ public class BulkFermenterInventoryWrapper implements IItemHandlerModifiable {
 
     @Override
     public void setStackInSlot(int slot, ItemStack stack) {
-        itemHandler.setStackInSlot(slot, stack);
+        if (itemHandler != null)
+            itemHandler.setStackInSlot(slot, stack);
     }
 
     @Override
     public int getSlots() {
-        return itemHandler.getSlots();
+        return itemHandler == null ? 0 : itemHandler.getSlots();
     }
 
     @Override
     public ItemStack getStackInSlot(int slot) {
-        return itemHandler.getStackInSlot(slot);
+        return itemHandler == null
+                ? ItemStack.EMPTY
+                : itemHandler.getStackInSlot(slot);
     }
 
     @Override
     public ItemStack insertItem(int slot, ItemStack stack, boolean simulate) {
-        return itemHandler.insertItem(slot, stack, simulate);
+        return itemHandler == null
+                ? stack
+                : itemHandler.insertItem(slot, stack, simulate);
     }
 
     @Override
     public ItemStack extractItem(int slot, int amount, boolean simulate) {
-        return itemHandler.extractItem(slot, amount, simulate);
+        return itemHandler == null
+                ? ItemStack.EMPTY
+                : itemHandler.extractItem(slot, amount, simulate);
     }
 
     @Override
     public int getSlotLimit(int slot) {
-        return itemHandler.getSlotLimit(slot);
+        return itemHandler == null
+                ? 0
+                : itemHandler.getSlotLimit(slot);
     }
 
     @Override
     public boolean isItemValid(int slot, ItemStack stack) {
-        return itemHandler.isItemValid(slot, stack);
+        return itemHandler != null
+                && itemHandler.isItemValid(slot, stack);
     }
 }


### PR DESCRIPTION
Added null checks to the override methods of the BulkFermenterInventoryWrapper class to fix a NullPointerException for [#387](https://github.com/george8188625/Create-Diesel-Generators/issues/387)

With the null checks in place, i was not able to reproduce the error anymore